### PR TITLE
Traverse branches seperately in `checkBody`

### DIFF
--- a/src/malebolgia.nim
+++ b/src/malebolgia.nim
@@ -200,9 +200,7 @@ macro checkBody(body: untyped): untyped =
     nnkExportStmt, nnkPragma, nnkCommentStmt,
     nnkTypeOfExpr, nnkMixinStmt, nnkBindStmt}
 
-  const BranchingNodes = {nnkStmtList, nnkStmtListExpr, nnkBlockStmt,
-    nnkWhileStmt, nnkForStmt,
-    nnkIfStmt, nnkElse, nnkElseExpr, nnkElifBranch, nnkElifExpr,
+  const BranchingNodes = {nnkIfStmt, nnkElse, nnkElseExpr, nnkElifBranch, nnkElifExpr,
     nnkOfBranch, nnkExceptBranch}
 
   proc isSpawn(n: NimNode): bool =


### PR DESCRIPTION
Without this patch, the following fails:

``` nim
import malebolgia

proc a(): int = 2
var b: int

var m = createMaster()
m.awaitAll:
  if true:
    m.spawn a() -> b
  else:
    m.spawn a() -> b
```

The patch doesn't cover try/except