### PR TITLE
Vendor (for linguist purposes) content of bench file so that this appears as a nim repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bench/* linguist-vendored


### PR DESCRIPTION
malebolgia appears to be a repo in html, as reported here: https://github.com/nim-lang/atlas/issues/59#issuecomment-1666205084

a possible fix implemented here is to vendor (for linguist purposes, github's component responsible for gathering language statistics) the content of bench folder (where all html files reside).
