### PR TITLE
Export `ThreadPoolSize` and `FixedChanSize`

### DIFF
--- a/malebolgia.nimble
+++ b/malebolgia.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.3.0"
+version       = "1.3.1"
 author        = "Araq"
 description   = "Malebolgia creates new spawns. Experiments with thread pools and related APIs."
 license       = "MIT"

--- a/src/malebolgia.nim
+++ b/src/malebolgia.nim
@@ -82,10 +82,10 @@ proc waitForCompletions(m: var Master) =
 # thread pool independent of the 'master':
 
 const
-  FixedChanSize {.intdefine.} = 16 ## must be a power of two!
+  FixedChanSize* {.intdefine.} = 16 ## must be a power of two!
   FixedChanMask = FixedChanSize - 1
 
-  ThreadPoolSize {.intdefine.} = 8 # 24
+  ThreadPoolSize* {.intdefine.} = 8 # 24
 
 type
   PoolTask = object ## a task for the thread pool


### PR DESCRIPTION
As mentioned in the forum, these (in particular ThreadPoolSize) are useful to have in case one wants to make some decision in the importing code based on them.