### PR TITLE
Added option to set global thread number during runtime

### DIFF
--- a/tests/tasymmetric_load.nim
+++ b/tests/tasymmetric_load.nim
@@ -1,0 +1,27 @@
+import malebolgia
+
+import std/[os, atomics]
+
+malebolgiaSetup(numThr = 20)
+
+var
+  threadpool = createMaster(activeProducer = true)
+  busyThreads: Atomic[int]
+busyThreads.store 0
+
+let mainThreadId = getThreadId()
+
+proc findStartPositionsAndPlay() =
+  atomicInc busyThreads
+  echo "Started. Busy threads: ", busyThreads.load
+
+  sleep(1000)
+  if getThreadId() == mainThreadId:
+    sleep(10_000)
+
+  atomicDec busyThreads
+  echo "Finished. Busy threads: ", busyThreads.load
+
+threadpool.awaitAll:
+  for i in 1 .. 10000:
+    threadpool.spawn findStartPositionsAndPlay()


### PR DESCRIPTION
This is roughly my suggestion. Use case is that to run a program on different systems where I am each allowed to use half of all CPU threads.