### PR TITLE
Made change to parReduce to work with passed in type of original data…

### DIFF
--- a/src/malebolgia/paralgos.nim
+++ b/src/malebolgia/paralgos.nim
@@ -67,7 +67,7 @@ template parReduce*[T](data: openArray[T]; bulkSize: int;
       op(result, a[i])
 
   var m = createMaster()
-  var res = newSeq[int](data.len div bulkSize + 1)
+  var res = newSeq[T](data.len div bulkSize + 1)
   var r = 0
   m.awaitAll:
     var i = 0


### PR DESCRIPTION
Changed template type of newSeq to T from int on line 70.
This will allow parReduce to work with any type T and not just ints.